### PR TITLE
Changes to support version 3.0.1 of boinc-server-docker.

### DIFF
--- a/manage/config/boinc-server-docker-expose-mysql.yml
+++ b/manage/config/boinc-server-docker-expose-mysql.yml
@@ -1,7 +1,7 @@
 #This file extends the settings from https://github.com/marius311/boinc-server-docker so that
 #the mysql port is open.  This lets the tests query the database.  However, this is likely
 #insecure for any sort of standard usage.
-version: "3"
+version: "3.4"
 
 services:
   mysql:

--- a/manage/roles/build-boinc-docker/tasks/main.yml
+++ b/manage/roles/build-boinc-docker/tasks/main.yml
@@ -1,2 +1,3 @@
 - name: Build BOINC in docker container
   command: docker-compose build --no-cache chdir="{{base_dir}}/boinc-server-docker"
+  tags: build,boinc

--- a/manage/roles/clone-boinc-server-docker/tasks/clone_boinc_server_docker.yml
+++ b/manage/roles/clone-boinc-server-docker/tasks/clone_boinc_server_docker.yml
@@ -2,10 +2,10 @@
   file: path="{{base_dir}}/boinc-server-docker" state=absent
 
 - name: "Clone boinc-server-docker to {{base_dir}}"
-  command: git clone https://github.com/marius311/boinc-server-docker.git chdir="{{base_dir}}"
+  command: git clone https://github.com/TheAspens/boinc-server-docker.git chdir="{{base_dir}}"
 
-- name: "Use release 3.0.1 of boinc-server-docker"
-  command: git checkout tags/3.0.1 chdir="{{base_dir}}/boinc-server-docker"
+- name: "Use release 3.0.2 of boinc-server-docker"
+  command: git checkout tags/3.0.2 chdir="{{base_dir}}/boinc-server-docker"
   
 - name: Init some submodules
   command: git submodule init images/makeproject/boinc2docker images/makeproject/html/inc/phpmailer chdir="{{base_dir}}/boinc-server-docker"

--- a/manage/roles/clone-boinc-server-docker/tasks/clone_boinc_server_docker.yml
+++ b/manage/roles/clone-boinc-server-docker/tasks/clone_boinc_server_docker.yml
@@ -4,8 +4,8 @@
 - name: "Clone boinc-server-docker to {{base_dir}}"
   command: git clone https://github.com/marius311/boinc-server-docker.git chdir="{{base_dir}}"
 
-- name: "Use release 2.1.0 of boinc-server-docker"
-  command: git checkout tags/2.1.0 chdir="{{base_dir}}/boinc-server-docker"
+- name: "Use release 3.0.1 of boinc-server-docker"
+  command: git checkout tags/3.0.1 chdir="{{base_dir}}/boinc-server-docker"
   
 - name: Init some submodules
   command: git submodule init images/makeproject/boinc2docker images/makeproject/html/inc/phpmailer chdir="{{base_dir}}/boinc-server-docker"

--- a/manage/roles/start-containers/tasks/main.yml
+++ b/manage/roles/start-containers/tasks/main.yml
@@ -3,11 +3,14 @@
     src: config/boinc-server-docker-expose-mysql.yml
     dest: "{{base_dir}}/boinc-server-docker/boinc-server-docker-expose-mysql.yml"
     
-- name: Start docker apache and mysql containers
-  command: docker-compose -f docker-compose.yml -f boinc-server-docker-expose-mysql.yml up -d mysql apache chdir="{{base_dir}}/boinc-server-docker"
+- name: Start docker mysql containers
+  command: docker-compose -f docker-compose.yml -f boinc-server-docker-expose-mysql.yml up -d mysql chdir="{{base_dir}}/boinc-server-docker"
 
 - name: Start docker makeprojectcontainer
   command: docker-compose -f docker-compose.yml -f boinc-server-docker-expose-mysql.yml up makeproject chdir="{{base_dir}}/boinc-server-docker"
+
+- name: Start docker apache containers
+  command: docker-compose -f docker-compose.yml -f boinc-server-docker-expose-mysql.yml up -d apache chdir="{{base_dir}}/boinc-server-docker"
 
 - name: Remove mysql port opening file
   file:


### PR DESCRIPTION
Update to version 3.0.1. so that once boinc-server-docker fixes the issue with psysh the framework will be usable again. (note that we will have to advance to 3.0.2 in order to pick up that change).