### PR TITLE
Fix overrided function declaration

### DIFF
--- a/tests/config-tests/project_configuration.php
+++ b/tests/config-tests/project_configuration.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 final class ProjectConfigurationTest extends TestCase
 {
 
-    public function setUp()
+    public function setUp(): void
     {
        $base_url = sprintf("%s://%s/%s/", protocol, host, base );
        $this->http = new GuzzleHttp\Client(['base_uri' => $base_url]);
@@ -31,7 +31,8 @@ final class ProjectConfigurationTest extends TestCase
 	$this->assertEquals($base_url, (string) $xml->web_rpc_url_base);
     }
 
-    public function tearDown() {
+    public function tearDown(): void
+    {
         $this->http = null;
     }
 

--- a/tests/user-tests/create_account.php
+++ b/tests/user-tests/create_account.php
@@ -15,7 +15,7 @@ final class CreateAccountTest extends TestCase
     var $email;
     var $hash;
 
-    public function setUp()
+    public function setUp(): void
     {
        $base_url = sprintf("%s://%s/%s/", protocol, host, base );
        $this->http = new GuzzleHttp\Client(['base_uri' => $base_url]);
@@ -98,7 +98,8 @@ final class CreateAccountTest extends TestCase
         $this->assertCount( 0, $xml->success);
     }
     
-    public function tearDown() {
+    public function tearDown(): void
+    {
         $this->http = null;
     }
 


### PR DESCRIPTION
PHP Fatal error:  Declaration of ProjectConfigurationTest::setUp() must be compatible with PHPUnit\Framework\TestCase::setUp(): void in /home/runner/work/boinc/bst/tests/config-tests/project_configuration.php on line 9
PHP Stack trace:
PHP   1. {main}() /home/runner/work/boinc/bst/tests/vendor/phpunit/phpunit/phpunit:0
PHP   2. PHPUnit\TextUI\Command::main($exit = *uninitialized*) /home/runner/work/boinc/bst/tests/vendor/phpunit/phpunit/phpunit:61
PHP   3. PHPUnit\TextUI\Command->run($argv = [0 => './vendor/bin/phpunit'], $exit = TRUE) /home/runner/work/boinc/bst/tests/vendor/phpunit/phpunit/src/TextUI/Command.php:95
PHP   4. PHPUnit\TextUI\Command->handleArguments($argv = [0 => './vendor/bin/phpunit']) /home/runner/work/boinc/bst/tests/vendor/phpunit/phpunit/src/TextUI/Command.php:110
PHP   5. PHPUnit\TextUI\TestSuiteMapper->map($configuration = class PHPUnit\TextUI\XmlConfiguration\TestSuiteCollection { private $testSuites = [0 => class PHPUnit\TextUI\XmlConfiguration\TestSuite { ... }] }, $filter = '') /home/runner/work/boinc/bst/tests/vendor/phpunit/phpunit/src/TextUI/Command.php:389
PHP   6. PHPUnit\Framework\TestSuite->addTestFiles($fileNames = [0 => '/home/runner/work/boinc/bst/tests/config-tests/project_configuration.php']) /home/runner/work/boinc/bst/tests/vendor/phpunit/phpunit/src/TextUI/TestSuiteMapper.php:67
PHP   7. PHPUnit\Framework\TestSuite->addTestFile($filename = '/home/runner/work/boinc/bst/tests/config-tests/project_configuration.php') /home/runner/work/boinc/bst/tests/vendor/phpunit/phpunit/src/Framework/TestSuite.php:530
PHP   8. PHPUnit\Util\FileLoader::checkAndLoad($filename = '/home/runner/work/boinc/bst/tests/config-tests/project_configuration.php') /home/runner/work/boinc/bst/tests/vendor/phpunit/phpunit/src/Framework/TestSuite.php:402
PHP   9. PHPUnit\Util\FileLoader::load($filename = '/home/runner/work/boinc/bst/tests/config-tests/project_configuration.php') /home/runner/work/boinc/bst/tests/vendor/phpunit/phpunit/src/Util/FileLoader.php:49
PHP  10. include_once() /home/runner/work/boinc/bst/tests/vendor/phpunit/phpunit/src/Util/FileLoader.php:65
Script ./vendor/bin/phpunit handling the test event returned with error code 255
Error: Process completed with exit code 1.

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>